### PR TITLE
Fix cors problem

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -3,6 +3,7 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.enableCors();
   await app.listen(8080);
 }
 bootstrap();


### PR DESCRIPTION
The `getTokenAfterFacebookSignIn` endpoint was failing, at least on my environment, due to cors not enabled. This PR fixes the issue.